### PR TITLE
Added support for parsing optional <cas:attributes> element

### DIFF
--- a/lib/AuthCAS.pm
+++ b/lib/AuthCAS.pm
@@ -470,11 +470,20 @@ sub validateST {
         return undef;
     }
 
-    my $user =
-      $xml->{'cas:serviceResponse'}[0]{'cas:authenticationSuccess'}[0]
-      {'cas:user'}[0];
+    my $authenticationSuccess = $xml->{'cas:serviceResponse'}[0]{'cas:authenticationSuccess'}[0];
+    my $user = $authenticationSuccess->{'cas:user'}[0];
 
-    ## If in Proxy mode, also retreave a PGT
+    ## If attributes exist, parse extra attributes
+    my %extra_attributes;
+    if ( defined $authenticationSuccess->{'cas:attributes'} )  {
+        my $attributes = $authenticationSuccess->{'cas:attributes'}[0];
+        foreach my $key (keys %$attributes) {
+            (my $extra_attribute_key = $key) =~ s/cas://;
+            $extra_attributes{$extra_attribute_key} = $attributes->{$key}[0];
+        }
+    }
+
+    ## If in Proxy mode, also retrieve a PGT
     if ( $self->{'proxy'} ) {
         my $pgtIou;
         if (
@@ -508,7 +517,7 @@ sub validateST {
         $self->{'pgtId'} = $pgtId;
     }
 
-    return ($user);
+    return wantarray ? ($user, \%extra_attributes) : $user;
 }
 
 =pod


### PR DESCRIPTION
I have implemented functionality for parsing the optional `cas:attributes` section of the ticket validation response. This  `validateST` now will create a hash of the attributes and return it along with the user.

Additional Information:

> [2.5.5. attributes [CAS 3.0]](http://jasig.github.io/cas/development/protocol/CAS-Protocol-Specification.html#attributes-cas-30)
> [CAS 3.0] The response document MAY include an optional cas:attributes element for additional authentication and/or user attributes.

The following code snippet enumerates the cas:attributes and creates a new hash, stripping off the `cas:` portion of each of the attribute keys before adding them:

```
    my %extra_attributes;
    if ( defined $authenticationSuccess->{'cas:attributes'} )  {
        my $attributes = $authenticationSuccess->{'cas:attributes'}[0];
        foreach my $key (keys %$attributes) {
            (my $extra_attribute_key = $key) =~ s/cas://;
            $extra_attributes{$extra_attribute_key} = $attributes->{$key}[0];
        }
    }
```

Also, rather then repeat the `$xml->{'cas:serviceResponse'}[0]{'cas:authenticationSuccess'}[0]`, I have changed the code to store this in the `$authenticationSuccess` variable, and refer to this for the user and attributes.

```
    my $authenticationSuccess = $xml->{'cas:serviceResponse'}[0]{'cas:authenticationSuccess'}[0];
    my $user = $authenticationSuccess->{'cas:user'}[0];
```

To support existing code but still provide the ability to return the attributes for those who wish to use them, I have altered the return value to be context aware:

```
return wantarray ? ($user, \%extra_attributes) : $user;
```

This allows someone to still do:

```
my $user = $cas->validateST('http://myserver/app.cgi', $ST);
```

or if they are interested in the cas:attributes, then:

```
my ($user, $attributes) = $cas->validateST('http://myserver/app.cgi', $ST);
```

I also have fixed up a spelling error in the comments:

```
## If in Proxy mode, also retrieve a PGT
```

I tested this code against the Ruby [CASino](https://github.com/rbCAS/CASino) CAS server.

Let me know if you have any questions or you request any changes. 

Thank you.
